### PR TITLE
fix: Use fingerprint icon from core

### DIFF
--- a/src/main/java/com/mastercard/labs/keyvault/SecretSSHUserPrivateKeyCredentials.java
+++ b/src/main/java/com/mastercard/labs/keyvault/SecretSSHUserPrivateKeyCredentials.java
@@ -96,35 +96,7 @@ public class SecretSSHUserPrivateKeyCredentials extends SecretStringCredentials 
          * {@inheritDoc}
          */
         public String getIconClassName() {
-            return "icon-ssh-credentials-ssh-key";
-        }
-
-        static {
-            for (String name : new String[]{
-                    "ssh-key"
-            }) {
-                IconSet.icons.addIcon(new Icon(
-                        String.format("icon-ssh-credentials-%s icon-sm", name),
-                        String.format("ssh-credentials/images/16x16/%s.png", name),
-                        Icon.ICON_SMALL_STYLE, IconType.PLUGIN)
-                );
-                IconSet.icons.addIcon(new Icon(
-                        String.format("icon-ssh-credentials-%s icon-md", name),
-                        String.format("ssh-credentials/images/24x24/%s.png", name),
-                        Icon.ICON_MEDIUM_STYLE, IconType.PLUGIN)
-                );
-                IconSet.icons.addIcon(new Icon(
-                        String.format("icon-ssh-credentials-%s icon-lg", name),
-                        String.format("ssh-credentials/images/32x32/%s.png", name),
-                        Icon.ICON_LARGE_STYLE, IconType.PLUGIN)
-                );
-                IconSet.icons.addIcon(new Icon(
-                        String.format("icon-ssh-credentials-%s icon-xlg", name),
-                        String.format("ssh-credentials/images/48x48/%s.png", name),
-                        Icon.ICON_XLARGE_STYLE, IconType.PLUGIN)
-                );
-            }
-
+            return "icon-fingerprint";
         }
     }
 }


### PR DESCRIPTION
The change proposed utilizes the corresponding icon from core, which respects themes properly.
Current implementation on dark mode:
![Bildschirmfoto 2022-06-23 um 00 36 29](https://user-images.githubusercontent.com/13383509/175166302-c4e6c83c-7a75-44fe-9f30-02dc9d3d0e20.png)
Proposed change:
![Bildschirmfoto 2022-06-23 um 00 39 23](https://user-images.githubusercontent.com/13383509/175166311-99a232be-b9bb-4a7e-a176-b889ca25ae53.png)

cc @mastercard-rob   
